### PR TITLE
Add trace image rotation controls

### DIFF
--- a/.squad/agents/bishop/history.md
+++ b/.squad/agents/bishop/history.md
@@ -9,3 +9,29 @@
 ## Learnings
 
 - Initial platform ownership assigned for integration and performance work.
+- **2026-05-01:** Code review identified 5 critical platform/performance risks:
+  1. Image memory management (OOM risk on tablets with large reference images)
+  2. Touch/stylus input latency optimization (1-5ms latency critical for Surface Pen)
+  3. App lifecycle resource management (suspend/resume/terminate cleanup)
+  4. Pen/stylus pressure and tilt data capture (required for professional workflows)
+  5. Performance instrumentation framework (no current metrics/telemetry)
+- **Architecture observations:**
+  - SkiaSharp 3.119.2 handles complex rendering (pan, zoom, rotate, opacity) but no performance metrics
+  - ScreenWakeService properly abstracts platform wake-lock APIs (DisplayRequest Windows, WindowManagerFlags Android)
+  - ImagePickerService caches to FileSystem.CacheDirectory but lacks memory bounds or LRU eviction
+  - Animation mode supports onion-skin overlays (multiple frame rendering) but no tested on low-RAM devices
+  - MVVM structure clean; state containers (TraceImageState, AnimationSessionState) are POCOs
+- **Key file paths:**
+  - Services: `src/LightPad.App/Services/` (IScreenWakeService, IImagePickerService, ISettingsService)
+  - Platform-specific: `src/LightPad.App/Platforms/Windows` (Package.appxmanifest, app.manifest)
+  - Views use large SkiaSharp canvases in LightboxPage, TracePage, AnimationPage
+- **Design doc alignment:** MVP focuses on basic lightbox + trace + lock controls. Performance and advanced input not yet scoped.
+
+## Team Updates
+
+### 2026-05-01T17:35:50Z (Scribe Decision Merge)
+- Scribe synchronized **Platform Risk Assessment** decision into active decisions ledger.
+- Decision confirmed: sequenced critical path (image memory #11 + lifecycle #13), high-value (input latency #12 + stylus data #15), and quality (instrumentation #17).
+- Estimated 2-3 weeks to address all risks. Requires expanded service layer (IPointerEventService, IImageMemoryService, IFrameTimingService) and lifecycle hooks.
+- Cross-team decisions now merged: Session Persistence Strategy (Ripley), UX Touch Workflow (Hicks) also entered ledger.
+- Decision inbox cleared (3 items processed).

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -11,6 +11,7 @@
 - Initial UI ownership assigned for MAUI interaction and experience design.
 - **Architecture:** MVVM structure with solid separation between Views (XAML), ViewModels, Models, and Services. SkiaSharp used for advanced image rendering (zoom, rotation) in Trace/Animation modes.
 - **Touch-first design considerations:** LightboxPage and TracePage use tap gesture recognition for lock toggling. Auto-hide pattern implemented but timing may need refinement. Surface Pen and stylus support require careful gesture handling to avoid accidental triggers during precision work.
+- Trace rotation is driven by TraceViewModel.RotationAngle, persisted in TraceImageState.Rotation, and rendered via SkiaSharp canvas rotation in TracePage.
 - **UX gaps identified (2026-05-01):** 
   - No visual gesture hints on first launch (users discover pinch/zoom/rotate by trial)
   - Missing undo/redo in Trace mode for image state changes

--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -9,3 +9,21 @@
 ## Learnings
 
 - Initial UI ownership assigned for MAUI interaction and experience design.
+- **Architecture:** MVVM structure with solid separation between Views (XAML), ViewModels, Models, and Services. SkiaSharp used for advanced image rendering (zoom, rotation) in Trace/Animation modes.
+- **Touch-first design considerations:** LightboxPage and TracePage use tap gesture recognition for lock toggling. Auto-hide pattern implemented but timing may need refinement. Surface Pen and stylus support require careful gesture handling to avoid accidental triggers during precision work.
+- **UX gaps identified (2026-05-01):** 
+  - No visual gesture hints on first launch (users discover pinch/zoom/rotate by trial)
+  - Missing undo/redo in Trace mode for image state changes
+  - No haptic feedback for lock/unlock transitions (subtle on touch devices)
+  - Control auto-hide timing lacks user configurability
+  - No quick-access preset swatches in Trace mode for rapid light adjustments
+- **GitHub issues created:** #2 (gestures), #4 (undo/redo), #6 (haptics), #8 (auto-hide), #10 (presets)
+- **Project state:** MVP features mostly complete; focus now on UX polish and discoverability for touch workflows.
+
+## Team Updates
+
+### 2026-05-01T17:35:50Z (Scribe Decision Merge)
+- Scribe synchronized **UX Touch Workflow Friction Points** decision into active decisions ledger.
+- Decision confirmed: prioritize gesture hints (#2) + quick presets (#10) as high-value; haptics (#6) + control timing (#8) as medium; undo/redo (#4) as nice-to-have.
+- Cross-team decisions now merged: Session Persistence Strategy (Ripley), Platform Risk Assessment (Bishop) also entered ledger.
+- Decision inbox cleared (3 items processed).

--- a/.squad/agents/lambert/history.md
+++ b/.squad/agents/lambert/history.md
@@ -9,3 +9,48 @@
 ## Learnings
 
 - Initial QA ownership assigned for test planning and coverage.
+
+### 2026-05-01T18:35:50 — Testing Gap Analysis and Issue Creation
+
+**Key Findings:**
+- **No unit tests exist** in the project; critical ViewModels (TraceViewModel, LightboxViewModel, AnimationViewModel, BaseViewModel) have untested state management and property binding logic
+- **No integration tests** for platform services (IScreenWakeService, IImagePickerService); cross-platform deployment risk on Windows Surface and Android tablets
+- **No regression test suite** for core drawing workflows (zoom, pan, rotation, opacity, lock/unlock, gesture handling); high risk of silent failures during refactoring
+- **No E2E test plan** documented; manual testing is inconsistent and edge cases are untested
+
+**Architecture Observations:**
+- BaseViewModel uses MVVM pattern with INotifyPropertyChanged and SetProperty<T> helper—good foundation for unit testing with mocking
+- ViewModels have complex state management: TraceViewModel manages zoom bounds (0.5–4.0), offset tracking, rotation, opacity, and lock state
+- Service layer clearly abstracted via interfaces (ISettingsService, IImagePickerService, IScreenWakeService)—design supports testability
+- Models are simple POCOs (TraceImageState, LightColorPreset, etc.)—easy to test
+- SettingsService uses MAUI Preferences.Default—needs mocking strategy for tests
+- No existing CI/CD pipeline configuration observed yet (check .github/workflows)
+
+**Created Issues:**
+- **#14**: Create unit test suite for ViewModels (type:chore, squad:lambert) — xUnit + Moq for property binding and state validation
+- **#16**: Create integration tests for platform-specific services (type:chore, squad:lambert) — ScreenWakeService, ImagePickerService on Windows and Android
+- **#18**: Build regression test suite for critical drawing workflows (type:chore, squad:lambert) — gesture handling, zoom/pan/rotate/opacity, lock state
+- **#19**: Create E2E test plan and validation checklist for cross-platform scenarios (type:spike, squad:lambert) — Windows Surface + Android tablet workflows
+
+**Recommendations for Implementation:**
+1. Start with unit tests (issue #14) using xUnit and Moq; establish mocking patterns for services
+2. Add integration tests (issue #16) against actual platform APIs; document permission/setup requirements
+3. Build regression suite (issue #18) to protect core workflows from refactoring regressions
+4. Execute E2E spike (issue #19) to document test scenarios before broader automation
+
+**Risk Areas Identified:**
+- Screen wake behavior critical for drawing workflows (mid-session sleep = data loss UX risk)
+- Gesture conflicts under high-frequency input (stylus on Surface, touch on Android)
+- Zoom/pan/rotation state consistency across platforms
+- Permission issues on Android (camera, storage, device power)
+- Platform-specific rendering edge cases with SkiaSharp
+
+## Team Updates
+
+### 2026-05-01T17:35:50Z (Scribe Decision Merge)
+- Scribe synchronized cross-team decisions into active decisions ledger:
+  - **Session Persistence Strategy** (Ripley) — app-scoped local storage for offline-capable session recovery
+  - **Platform Risk Assessment** (Bishop) — 5 critical platform/performance risks sequenced for v1 planning
+  - **UX Touch Workflow** (Hicks) — 5 UX friction points prioritized for polish sprint
+- All 12 GitHub issues (created by Ripley, Hicks, Bishop, Lambert) now have corresponding decisions in ledger.
+- Decision inbox cleared (3 items processed). Team consensus model now operational.

--- a/.squad/agents/ripley/history.md
+++ b/.squad/agents/ripley/history.md
@@ -26,3 +26,19 @@
 - Phased delivery model confirmed: architecture/contracts → plain lightbox → trace mode → safe controls/settings → quality/CI hardening → release readiness.
 - Animation and onion skin deferred to post-v1 backlog; iPad readiness preserved through platform abstraction and iOS compile readiness in each phase.
 - Decision inbox cleared (2 items processed).
+
+### 2026-05-01T18:35:50Z (Ripley Code Review + Backlog Grooming)
+- Reviewed app architecture, design doc, and implementation scaffolding across ViewModels, Services, and Models.
+- Scaffold is solid: MVVM contracts established (BaseViewModel, IImagePickerService, IScreenWakeService, ISettingsService); SkiaSharp integrated for image rendering.
+- State management via TraceSessionState, AnimationSessionState, and per-view settings; ServiceProviderHelper pattern for DI access.
+- Identified 5 feature gaps vs. design doc and platform requirements: image rotation, grid overlay, gesture locking for stylus, session persistence, platform-specific brightness.
+- Created GitHub issues #1, #3, #5, #7, #9 to address these gaps with clear acceptance criteria.
+- Architecture decision: Session persistence should serialize to app-scoped storage (not cloud) to support airplane mode and offline workflows on tablets.
+- Platform consideration: Stylus/pen input handling must distinguish input types and respect lock state; affects UX quality on Surface + Android tablets.
+
+### 2026-05-01T17:35:50Z (Scribe Decision Merge)
+- Scribe synchronized **Session Persistence Strategy** decision into active decisions ledger.
+- Decision confirmed: use app-scoped local file storage (JSON serialization) for TraceSessionState and AnimationSessionState.
+- Auto-save on state changes; cap history to last 5 sessions. Offline-capable, MVP-aligned, upgradeable to cloud sync later.
+- Cross-team decisions now merged: Platform Risk Assessment (Bishop), UX Touch Workflow (Hicks) also entered ledger.
+- Decision inbox cleared (3 items processed).

--- a/.squad/decisions.md
+++ b/.squad/decisions.md
@@ -16,6 +16,27 @@
 - **Decision:** Execute v1 in phased slices: architecture/contracts, plain lightbox, trace mode, safe controls/settings, quality/CI hardening, and release readiness; treat animation/onion skin as post-v1 backlog.
 - **Consequences:** Delivery stays aligned with MVP must-haves from the design doc, minimizes cross-platform risk early, and preserves a clean path to iPad enablement by keeping platform abstractions and iOS compile readiness in each phase.
 
+### Platform Risk Assessment – May 2026
+- **Date:** 2026-05-01T18:35:50.743+01:00
+- **Owner:** Bishop
+- **Context:** Code review of LightPad v1 MAUI scaffold identified 5 critical platform/performance risks blocking professional Surface Pen and Android tablet workflows. All risks have GitHub issues created (#11, #12, #13, #15, #17).
+- **Decision:** Address in v1 planning: (1) Image memory management (#11) + App lifecycle (#13) as critical path (prevents crashes); (2) Input latency (#12) + Stylus data (#15) as high-value (enables professional workflows); (3) Performance instrumentation (#17) as quality enabler. All 5 scoped as follow-up features unless team decides to include before v1 release.
+- **Consequences:** Estimated 2-3 weeks to address all risks. Enables professional Surface Pen + Android workflows. Requires expanded service layer (IPointerEventService, IImageMemoryService, IFrameTimingService) and lifecycle hooks in App.xaml.cs.
+
+### UX Touch Workflow Friction Points – May 2026
+- **Date:** 2026-05-01T18:35:50.743+01:00
+- **Owner:** Hicks
+- **Context:** UX review identified 5 friction points in touch workflows: gesture discovery, state management (undo), haptic feedback, control timing configurability, quick-access light presets.
+- **Decision:** Prioritize by workflow impact: (1) High priority: gesture hints (#2) and quick presets (#10) (reduce confusion and workflow interruption); (2) Medium: haptics (#6) and control timing (#8) (improve reliability and ergonomics); (3) Nice-to-have: undo/redo (#4).
+- **Consequences:** Improved user confidence and workflow speed on Surface and Android tablets. Consider bundling gesture hints + control improvements into a "UX Polish" sprint.
+
+### Session Persistence Strategy – May 2026
+- **Date:** 2026-05-01T18:35:50.743+01:00
+- **Owner:** Ripley
+- **Context:** Current session state (trace images, positions, zoom, animation frames) exists only in memory. Long workflows lose progress on crash, suspension, or power loss—unacceptable for artist workflows. Evaluated app-scoped local storage vs cloud sync vs platform preferences.
+- **Decision:** Use app-scoped local file storage. Serialize TraceSessionState and AnimationSessionState to JSON; save to FileSystem.AppDataDirectory/sessions/; auto-save on state changes; load most recent session on startup; cap history to last 5 sessions.
+- **Consequences:** Deterministic, offline-capable, user-controlled persistence. Aligns with v1 MVP scope. Easy to upgrade to cloud sync later if user demand justifies it. Enables artists to resume work safely across app crashes and device power loss.
+
 ## Governance
 
 - All meaningful changes require team consensus

--- a/.squad/skills/maui-session-state-pattern/SKILL.md
+++ b/.squad/skills/maui-session-state-pattern/SKILL.md
@@ -1,0 +1,102 @@
+# MAUI Session State Pattern
+
+**Date:** 2026-05-01T18:35:50.743+01:00
+**Owner:** Ripley
+**Applied In:** LightPad (TraceSessionState, AnimationSessionState, LightboxSettingsState)
+
+## Problem
+
+Cross-platform MAUI apps often need to preserve complex UI state (image positions, zoom, user selections) across navigation, background suspension, or app restarts. MAUI's built-in `Preferences` API is too limited for rich state objects, and ViewModel properties alone don't survive process death.
+
+## Solution
+
+Create **singleton session state classes** that:
+1. Encapsulate all stateful data for a feature (e.g., TraceSessionState for trace mode)
+2. Are registered in DI as `AddSingleton<T>()`
+3. Wrap immutable model objects (e.g., `TraceImageState`)
+4. Are injected into ViewModels, which bind UI to session state
+5. Can be serialized/deserialized for persistence
+
+## Pattern Structure
+
+```csharp
+// Models/TraceImageState.cs - immutable data contract
+public class TraceImageState
+{
+    public string FilePath { get; init; }
+    public double OffsetX { get; init; }
+    public double OffsetY { get; init; }
+    public double Zoom { get; init; }
+    public double Opacity { get; init; }
+    public double RotationDegrees { get; init; }
+}
+
+// Models/TraceSessionState.cs - mutable session container (singleton)
+public class TraceSessionState
+{
+    public TraceImageState ActiveImage { get; private set; }
+    
+    public void UpdateImage(TraceImageState newState)
+    {
+        ActiveImage = newState;
+        OnSessionChanged?.Invoke();
+    }
+    
+    public event Action OnSessionChanged;
+}
+
+// ViewModels/TraceViewModel.cs
+public class TraceViewModel : BaseViewModel
+{
+    private readonly TraceSessionState _sessionState;
+    
+    public TraceViewModel(TraceSessionState sessionState, ...)
+    {
+        _sessionState = sessionState;
+        // Bind UI commands to session state mutations
+    }
+}
+
+// MauiProgram.cs - register as singleton
+builder.Services.AddSingleton<TraceSessionState>();
+builder.Services.AddTransient<TraceViewModel>();
+```
+
+## Benefits
+
+- **State survives navigation**: ViewModels are transient, but session state is singleton → doesn't reset on page navigation
+- **Single source of truth**: No duplicate state in ViewModels or Views
+- **Serializable**: Easy to persist to storage or export
+- **Testable**: Inject mock session state into ViewModels
+- **Scales well**: Add new session state classes as features grow (e.g., AnimationSessionState, LayerSessionState)
+
+## Usage Notes
+
+- Mark session state classes as `sealed` to prevent accidental inheritance
+- Use immutable models (records or init-only properties) for data classes
+- Expose change events (e.g., `OnSessionChanged`) for reactive UI updates
+- For complex nested state, consider using a state management library (Redux, Flux) in later slices
+
+## Example: Auto-Save Pattern
+
+```csharp
+public class TraceViewModel : BaseViewModel
+{
+    public TraceViewModel(TraceSessionState sessionState, ...)
+    {
+        _sessionState = sessionState;
+        _sessionState.OnSessionChanged += AutoSaveSession;
+    }
+    
+    private async void AutoSaveSession()
+    {
+        var json = JsonConvert.SerializeObject(_sessionState);
+        await File.WriteAllTextAsync(sessionFilePath, json);
+    }
+}
+```
+
+## References
+
+- LightPad: `src/LightPad.App/Models/TraceSessionState.cs`
+- MAUI DI: https://learn.microsoft.com/en-us/dotnet/maui/fundamentals/dependency-injection

--- a/src/LightPad.App/ViewModels/TraceViewModel.cs
+++ b/src/LightPad.App/ViewModels/TraceViewModel.cs
@@ -14,6 +14,7 @@ public sealed class TraceViewModel : BaseViewModel
 {
     private const double MinZoom = 0.5;
     private const double MaxZoom = 4.0;
+    private const double RotationStep = 5.0;
     private readonly IImagePickerService _imagePickerService;
     private readonly IScreenWakeService _screenWakeService;
     private readonly ISettingsService _settingsService;
@@ -21,6 +22,7 @@ public sealed class TraceViewModel : BaseViewModel
     private double _offsetX;
     private double _offsetY;
     private double _zoom;
+    private double _rotation;
     private double _imageOpacity;
     private bool _isImageLocked;
     private string? _imagePath;
@@ -47,6 +49,7 @@ public sealed class TraceViewModel : BaseViewModel
         _offsetX = _activeImage.OffsetX;
         _offsetY = _activeImage.OffsetY;
         _zoom = LightSurfaceStyleCalculator.Clamp(_activeImage.Zoom, MinZoom, MaxZoom);
+        _rotation = NormalizeRotation(_activeImage.Rotation);
         _imageOpacity = LightSurfaceStyleCalculator.Clamp(
             _activeImage.FilePath is null ? settingsService.DefaultTraceOpacity : _activeImage.Opacity,
             0.1,
@@ -57,6 +60,7 @@ public sealed class TraceViewModel : BaseViewModel
         _surfacePreset = settingsService.SelectedPreset;
         _surfaceCustomColorHex = LightSurfaceStyleCalculator.NormalizeHexOrDefault(settingsService.CustomColorHex, "#FFFFFF");
         _statusMessage = CreateStatusMessage();
+        _activeImage.Rotation = _rotation;
         _activeImage.Opacity = _imageOpacity;
 
         BackCommand = new Command(async () => await Shell.Current.GoToAsync(".."));
@@ -66,6 +70,8 @@ public sealed class TraceViewModel : BaseViewModel
         ClearImageCommand = new Command(ClearImage, () => HasImage && !IsBusy);
         ZoomOutCommand = new Command(() => NudgeZoom(-0.15), () => HasImage && !IsBusy);
         ZoomInCommand = new Command(() => NudgeZoom(0.15), () => HasImage && !IsBusy);
+        RotateLeftCommand = new Command(() => NudgeRotation(-RotationStep), () => CanManipulateImage && !IsBusy);
+        RotateRightCommand = new Command(() => NudgeRotation(RotationStep), () => CanManipulateImage && !IsBusy);
         ToggleControlsCommand = new Command(ToggleControls);
     }
 
@@ -84,6 +90,10 @@ public sealed class TraceViewModel : BaseViewModel
     public Command ZoomOutCommand { get; }
 
     public Command ZoomInCommand { get; }
+
+    public Command RotateLeftCommand { get; }
+
+    public Command RotateRightCommand { get; }
 
     public Command ToggleControlsCommand { get; }
 
@@ -157,6 +167,22 @@ public sealed class TraceViewModel : BaseViewModel
         }
     }
 
+    public double RotationAngle
+    {
+        get => _rotation;
+        set
+        {
+            var normalizedValue = NormalizeRotation(value);
+            if (!SetProperty(ref _rotation, normalizedValue))
+            {
+                return;
+            }
+
+            _activeImage.Rotation = normalizedValue;
+            UpdateStatusMessage();
+        }
+    }
+
     public double ImageOpacity
     {
         get => _imageOpacity;
@@ -188,6 +214,7 @@ public sealed class TraceViewModel : BaseViewModel
             OnPropertyChanged(nameof(LockButtonText));
             OnPropertyChanged(nameof(LockStatusText));
             OnPropertyChanged(nameof(CanManipulateImage));
+            RaiseCommandStateChanged();
             UpdateStatusMessage();
         }
     }
@@ -322,6 +349,7 @@ public sealed class TraceViewModel : BaseViewModel
         OffsetX = 0.0;
         OffsetY = 0.0;
         Zoom = 1.0;
+        RotationAngle = 0.0;
         if (HasImage)
         {
             UpdateStatusMessage($"Reset view for {ImageName}.");
@@ -346,6 +374,8 @@ public sealed class TraceViewModel : BaseViewModel
         ClearImageCommand.ChangeCanExecute();
         ZoomOutCommand.ChangeCanExecute();
         ZoomInCommand.ChangeCanExecute();
+        RotateLeftCommand.ChangeCanExecute();
+        RotateRightCommand.ChangeCanExecute();
     }
 
     private void ClearImage()
@@ -359,6 +389,7 @@ public sealed class TraceViewModel : BaseViewModel
         OffsetX = 0.0;
         OffsetY = 0.0;
         Zoom = 1.0;
+        RotationAngle = 0.0;
         ImageOpacity = _settingsService.DefaultTraceOpacity;
         IsImageLocked = false;
         UpdateStatusMessage("Trace image cleared. Import a new reference image to continue.");
@@ -372,6 +403,16 @@ public sealed class TraceViewModel : BaseViewModel
         }
 
         Zoom += delta;
+    }
+
+    private void NudgeRotation(double delta)
+    {
+        if (!CanManipulateImage)
+        {
+            return;
+        }
+
+        RotationAngle = _rotation + delta;
     }
 
     private void ToggleControls()
@@ -392,6 +433,17 @@ public sealed class TraceViewModel : BaseViewModel
             return "No trace image loaded yet. Import a single image to start panning and zooming.";
         }
 
-        return $"{ImageName}: zoom {Zoom:0.00}x, opacity {ImageOpacity:P0}, offset ({OffsetX:0}, {OffsetY:0}).";
+        return $"{ImageName}: zoom {Zoom:0.00}x, rotation {RotationAngle:0}°, opacity {ImageOpacity:P0}, offset ({OffsetX:0}, {OffsetY:0}).";
+    }
+
+    private static double NormalizeRotation(double value)
+    {
+        var normalized = value % 360.0;
+        if (normalized < 0)
+        {
+            normalized += 360.0;
+        }
+
+        return normalized;
     }
 }

--- a/src/LightPad.App/Views/TracePage.xaml
+++ b/src/LightPad.App/Views/TracePage.xaml
@@ -246,6 +246,45 @@
                                     MinimumTrackColor="#F5E7A1"
                                     MaximumTrackColor="#4A4A4A"
                                     HeightRequest="40" />
+
+                            <Grid ColumnDefinitions="*,Auto,Auto,Auto"
+                                  ColumnSpacing="10">
+                                <Label Text="Rotation"
+                                       TextColor="White"
+                                       FontAttributes="Bold"
+                                       VerticalOptions="Center" />
+                                <Button Grid.Column="1"
+                                        Text="Rotate -"
+                                        Command="{Binding RotateLeftCommand}"
+                                        BackgroundColor="#333333"
+                                        TextColor="White"
+                                        CornerRadius="20"
+                                        MinimumHeightRequest="44"
+                                        MinimumWidthRequest="90"
+                                        IsEnabled="{Binding CanManipulateImage}" />
+                                <Button Grid.Column="2"
+                                        Text="Rotate +"
+                                        Command="{Binding RotateRightCommand}"
+                                        BackgroundColor="#333333"
+                                        TextColor="White"
+                                        CornerRadius="20"
+                                        MinimumHeightRequest="44"
+                                        MinimumWidthRequest="90"
+                                        IsEnabled="{Binding CanManipulateImage}" />
+                                <Label Grid.Column="3"
+                                       Text="{Binding RotationAngle, StringFormat='{0:0}°'}"
+                                       TextColor="White"
+                                       VerticalOptions="Center" />
+                            </Grid>
+
+                            <Slider Minimum="0"
+                                    Maximum="360"
+                                    Value="{Binding RotationAngle}"
+                                    ThumbColor="#F5E7A1"
+                                    MinimumTrackColor="#F5E7A1"
+                                    MaximumTrackColor="#4A4A4A"
+                                    HeightRequest="40"
+                                    IsEnabled="{Binding CanManipulateImage}" />
                         </VerticalStackLayout>
                     </ScrollView>
                 </Border>

--- a/src/LightPad.App/Views/TracePage.xaml.cs
+++ b/src/LightPad.App/Views/TracePage.xaml.cs
@@ -66,6 +66,7 @@ public partial class TracePage : ContentPage
             or nameof(TraceViewModel.OffsetX)
             or nameof(TraceViewModel.OffsetY)
             or nameof(TraceViewModel.Zoom)
+            or nameof(TraceViewModel.RotationAngle)
             or nameof(TraceViewModel.ImageOpacity)
             or nameof(TraceViewModel.IsImageLocked))
         {
@@ -114,8 +115,15 @@ public partial class TracePage : ContentPage
         };
         var sampling = new SKSamplingOptions(SKFilterMode.Linear, SKMipmapMode.None);
         using var image = SKImage.FromBitmap(_traceBitmap);
+        var centerX = targetRect.MidX;
+        var centerY = targetRect.MidY;
 
+        canvas.Save();
+        canvas.Translate(centerX, centerY);
+        canvas.RotateDegrees((float)_viewModel.RotationAngle);
+        canvas.Translate(-centerX, -centerY);
         canvas.DrawImage(image, targetRect, sampling, bitmapPaint);
+        canvas.Restore();
     }
 
     private void OnImagePanUpdated(object? sender, PanUpdatedEventArgs e)


### PR DESCRIPTION
## Summary
- add rotation state + commands to TraceViewModel
- render rotation in TracePage canvas and add rotation controls in UI
- keep rotation persisted in trace session image state

## Testing
- dotnet build LightPad.sln -f net10.0-windows10.0.19041.0

Closes #1