### PR TITLE
Add grid overlay with adjustable spacing to trace view

### DIFF
--- a/src/LightPad.App/Models/TraceSessionState.cs
+++ b/src/LightPad.App/Models/TraceSessionState.cs
@@ -5,4 +5,8 @@ public sealed class TraceSessionState
     public TraceImageState ActiveImage { get; } = new();
 
     public bool IsSessionLocked { get; set; }
+
+    public bool GridVisible { get; set; }
+
+    public double GridSpacing { get; set; } = 48.0;
 }

--- a/src/LightPad.App/ViewModels/TraceViewModel.cs
+++ b/src/LightPad.App/ViewModels/TraceViewModel.cs
@@ -14,6 +14,8 @@ public sealed class TraceViewModel : BaseViewModel
 {
     private const double MinZoom = 0.5;
     private const double MaxZoom = 4.0;
+    private const double MinGridSpacing = 16.0;
+    private const double MaxGridSpacing = 160.0;
     private readonly IImagePickerService _imagePickerService;
     private readonly IScreenWakeService _screenWakeService;
     private readonly ISettingsService _settingsService;
@@ -27,6 +29,8 @@ public sealed class TraceViewModel : BaseViewModel
     private string _statusMessage;
     private bool _isBusy;
     private bool _isControlsExpanded = true;
+    private bool _isGridVisible;
+    private double _gridSpacing;
     private double _surfaceBrightness;
     private double _surfaceColorTemperature;
     private LightColorPreset _surfacePreset;
@@ -52,12 +56,15 @@ public sealed class TraceViewModel : BaseViewModel
             0.1,
             1.0);
         _isImageLocked = _activeImage.IsLocked;
+        _isGridVisible = sessionState.GridVisible;
+        _gridSpacing = LightSurfaceStyleCalculator.Clamp(sessionState.GridSpacing, MinGridSpacing, MaxGridSpacing);
         _surfaceBrightness = LightSurfaceStyleCalculator.Clamp(settingsService.Brightness, 0.05, 1.0);
         _surfaceColorTemperature = LightSurfaceStyleCalculator.Clamp(settingsService.ColorTemperature, 2700.0, 9000.0);
         _surfacePreset = settingsService.SelectedPreset;
         _surfaceCustomColorHex = LightSurfaceStyleCalculator.NormalizeHexOrDefault(settingsService.CustomColorHex, "#FFFFFF");
         _statusMessage = CreateStatusMessage();
         _activeImage.Opacity = _imageOpacity;
+        SessionState.GridSpacing = _gridSpacing;
 
         BackCommand = new Command(async () => await Shell.Current.GoToAsync(".."));
         ImportImageCommand = new Command(async () => await ImportImageAsync(), () => !IsBusy);
@@ -66,6 +73,7 @@ public sealed class TraceViewModel : BaseViewModel
         ClearImageCommand = new Command(ClearImage, () => HasImage && !IsBusy);
         ZoomOutCommand = new Command(() => NudgeZoom(-0.15), () => HasImage && !IsBusy);
         ZoomInCommand = new Command(() => NudgeZoom(0.15), () => HasImage && !IsBusy);
+        ToggleGridCommand = new Command(ToggleGrid);
         ToggleControlsCommand = new Command(ToggleControls);
     }
 
@@ -84,6 +92,8 @@ public sealed class TraceViewModel : BaseViewModel
     public Command ZoomOutCommand { get; }
 
     public Command ZoomInCommand { get; }
+
+    public Command ToggleGridCommand { get; }
 
     public Command ToggleControlsCommand { get; }
 
@@ -208,6 +218,38 @@ public sealed class TraceViewModel : BaseViewModel
 
     public bool CanManipulateImage => HasImage && !IsImageLocked;
 
+    public bool IsGridVisible
+    {
+        get => _isGridVisible;
+        set
+        {
+            if (!SetProperty(ref _isGridVisible, value))
+            {
+                return;
+            }
+
+            SessionState.GridVisible = value;
+            OnPropertyChanged(nameof(GridButtonText));
+            UpdateStatusMessage();
+        }
+    }
+
+    public double GridSpacing
+    {
+        get => _gridSpacing;
+        set
+        {
+            var clampedValue = LightSurfaceStyleCalculator.Clamp(value, MinGridSpacing, MaxGridSpacing);
+            if (!SetProperty(ref _gridSpacing, clampedValue))
+            {
+                return;
+            }
+
+            SessionState.GridSpacing = clampedValue;
+            UpdateStatusMessage();
+        }
+    }
+
     public bool IsControlsExpanded
     {
         get => _isControlsExpanded;
@@ -226,6 +268,8 @@ public sealed class TraceViewModel : BaseViewModel
     public bool IsFloatingShowToolsVisible => !IsControlsExpanded;
 
     public string LockButtonText => IsImageLocked ? "Unlock Image" : "Lock Image";
+
+    public string GridButtonText => IsGridVisible ? "Hide Grid" : "Show Grid";
 
     public string ControlsToggleText => IsControlsExpanded ? "Hide Tools" : "Show Tools";
 
@@ -379,6 +423,11 @@ public sealed class TraceViewModel : BaseViewModel
         IsControlsExpanded = !IsControlsExpanded;
     }
 
+    private void ToggleGrid()
+    {
+        IsGridVisible = !IsGridVisible;
+    }
+
     private void UpdateStatusMessage(string? overrideMessage = null)
     {
         _statusMessage = overrideMessage ?? CreateStatusMessage();
@@ -392,6 +441,7 @@ public sealed class TraceViewModel : BaseViewModel
             return "No trace image loaded yet. Import a single image to start panning and zooming.";
         }
 
-        return $"{ImageName}: zoom {Zoom:0.00}x, opacity {ImageOpacity:P0}, offset ({OffsetX:0}, {OffsetY:0}).";
+        var gridText = IsGridVisible ? $"grid {GridSpacing:0}px" : "grid off";
+        return $"{ImageName}: zoom {Zoom:0.00}x, opacity {ImageOpacity:P0}, {gridText}, offset ({OffsetX:0}, {OffsetY:0}).";
     }
 }

--- a/src/LightPad.App/Views/TracePage.xaml
+++ b/src/LightPad.App/Views/TracePage.xaml
@@ -246,6 +246,34 @@
                                     MinimumTrackColor="#F5E7A1"
                                     MaximumTrackColor="#4A4A4A"
                                     HeightRequest="40" />
+
+                            <Grid ColumnDefinitions="*,Auto,Auto"
+                                  ColumnSpacing="10">
+                                <Label Text="Grid Overlay"
+                                       TextColor="White"
+                                       FontAttributes="Bold"
+                                       VerticalOptions="Center" />
+                                <Button Grid.Column="1"
+                                        Text="{Binding GridButtonText}"
+                                        Command="{Binding ToggleGridCommand}"
+                                        BackgroundColor="#333333"
+                                        TextColor="White"
+                                        CornerRadius="20"
+                                        MinimumHeightRequest="44"
+                                        Padding="16,10" />
+                                <Label Grid.Column="2"
+                                       Text="{Binding GridSpacing, StringFormat='{0:0}px'}"
+                                       TextColor="White"
+                                       VerticalOptions="Center" />
+                            </Grid>
+
+                            <Slider Minimum="16"
+                                    Maximum="160"
+                                    Value="{Binding GridSpacing}"
+                                    ThumbColor="#F5E7A1"
+                                    MinimumTrackColor="#F5E7A1"
+                                    MaximumTrackColor="#4A4A4A"
+                                    HeightRequest="40" />
                         </VerticalStackLayout>
                     </ScrollView>
                 </Border>

--- a/src/LightPad.App/Views/TracePage.xaml.cs
+++ b/src/LightPad.App/Views/TracePage.xaml.cs
@@ -67,6 +67,8 @@ public partial class TracePage : ContentPage
             or nameof(TraceViewModel.OffsetY)
             or nameof(TraceViewModel.Zoom)
             or nameof(TraceViewModel.ImageOpacity)
+            or nameof(TraceViewModel.IsGridVisible)
+            or nameof(TraceViewModel.GridSpacing)
             or nameof(TraceViewModel.IsImageLocked))
         {
             TraceCanvas.InvalidateSurface();
@@ -89,6 +91,8 @@ public partial class TracePage : ContentPage
             24f,
             24f);
         canvas.DrawRoundRect(paperBounds, paperPaint);
+
+        DrawGrid(canvas, paperBounds);
 
         if (_traceBitmap is null || !_viewModel.HasImage)
         {
@@ -196,5 +200,60 @@ public partial class TracePage : ContentPage
         _traceBitmap?.Dispose();
         _traceBitmap = null;
         _loadedBitmapPath = null;
+    }
+
+    private void DrawGrid(SKCanvas canvas, SKRoundRect paperBounds)
+    {
+        if (!_viewModel.IsGridVisible)
+        {
+            return;
+        }
+
+        var paperRect = paperBounds.Rect;
+        var majorSpacing = (float)_viewModel.GridSpacing;
+        var minorSpacing = Math.Max(majorSpacing / 2f, 8f);
+        var lineColor = ResolveGridColor();
+        var accentColor = lineColor.WithAlpha((byte)Math.Min(255, lineColor.Alpha + 35));
+
+        canvas.Save();
+        canvas.ClipRoundRect(paperBounds, antialias: true);
+
+        using var minorPaint = new SKPaint
+        {
+            Color = lineColor,
+            StrokeWidth = 1f,
+            IsAntialias = true
+        };
+
+        using var majorPaint = new SKPaint
+        {
+            Color = accentColor,
+            StrokeWidth = 1.4f,
+            IsAntialias = true
+        };
+
+        DrawGridLines(canvas, paperRect, minorSpacing, minorPaint);
+        DrawGridLines(canvas, paperRect, majorSpacing, majorPaint);
+        canvas.Restore();
+    }
+
+    private static void DrawGridLines(SKCanvas canvas, SKRect bounds, float spacing, SKPaint paint)
+    {
+        for (var x = bounds.Left + spacing; x < bounds.Right; x += spacing)
+        {
+            canvas.DrawLine(x, bounds.Top, x, bounds.Bottom, paint);
+        }
+
+        for (var y = bounds.Top + spacing; y < bounds.Bottom; y += spacing)
+        {
+            canvas.DrawLine(bounds.Left, y, bounds.Right, y, paint);
+        }
+    }
+
+    private SKColor ResolveGridColor()
+    {
+        return _viewModel.TraceBackdropOverlayOpacity > 0.45
+            ? SKColor.Parse("#88FFF7CF")
+            : SKColor.Parse("#884A4332");
     }
 }


### PR DESCRIPTION
Closes #3
Implemented grid overlay feature in the trace view, including new properties for grid visibility and spacing in session state and view model. Updated the UI to allow toggling and adjusting the grid, and added drawing logic to render the grid on the canvas. Status messages now reflect the grid state.